### PR TITLE
Fix for issue #4, multiple pie charts being rendered

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ LazyData: TRUE
 Imports:
     jsonlite,
     htmlwidgets
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Suggests: knitr,
     rmarkdown,
     testthat

--- a/inst/htmlwidgets/pier.js
+++ b/inst/htmlwidgets/pier.js
@@ -28,6 +28,13 @@ HTMLWidgets.widget({
 
           renderValue: function(x, width, height) {
 
+             if(instance.lastValue){
+                  pie.destroy();
+             }
+             instance.lastValue=x;
+
+
+
             //console.log(x.size);
             // if size not set get window dimensions
             if (x.size) {
@@ -64,6 +71,7 @@ HTMLWidgets.widget({
 
             x.id = el.id;
             instance.x = x;
+
 
             console.log(x);
 

--- a/man/pie.footer.Rd
+++ b/man/pie.footer.Rd
@@ -4,8 +4,8 @@
 \alias{pie.footer}
 \title{pie.footer}
 \usage{
-pie.footer(pier, text = NULL, size = NULL, font = NULL, colour = NULL,
-  location = NULL)
+pie.footer(pier, text = NULL, size = NULL, font = NULL,
+  colour = NULL, location = NULL)
 }
 \arguments{
 \item{pier}{object}

--- a/man/pie.header.Rd
+++ b/man/pie.header.Rd
@@ -4,8 +4,8 @@
 \alias{pie.header}
 \title{pie.header}
 \usage{
-pie.header(pier, text = NULL, size = NULL, font = NULL, colour = NULL,
-  location = NULL)
+pie.header(pier, text = NULL, size = NULL, font = NULL,
+  colour = NULL, location = NULL)
 }
 \arguments{
 \item{pier}{object}

--- a/man/pie.size.Rd
+++ b/man/pie.size.Rd
@@ -4,7 +4,8 @@
 \alias{pie.size}
 \title{pie.size}
 \usage{
-pie.size(pier, outer = 90, inner = NULL, width = NULL, height = NULL)
+pie.size(pier, outer = 90, inner = NULL, width = NULL,
+  height = NULL)
 }
 \arguments{
 \item{pier}{object}

--- a/man/pie.subtitle.Rd
+++ b/man/pie.subtitle.Rd
@@ -4,8 +4,8 @@
 \alias{pie.subtitle}
 \title{pie.subtitle}
 \usage{
-pie.subtitle(pier, text = NULL, size = NULL, font = NULL, colour = NULL,
-  padding = NULL)
+pie.subtitle(pier, text = NULL, size = NULL, font = NULL,
+  colour = NULL, padding = NULL)
 }
 \arguments{
 \item{pier}{object}

--- a/man/pie.tooltips.Rd
+++ b/man/pie.tooltips.Rd
@@ -5,10 +5,11 @@
 \title{pie.tooltips}
 \usage{
 pie.tooltips(pier, enabled = TRUE, type = "placeholder",
-  string = "{label}: {value}, {percentage}\%", placeholderParser = NULL,
-  fadeInSpeed = 250, backgroundColor = "#000000", backgroundOpacity = 0.5,
-  color = "#efefef", borderRadius = 2, font = "arial", fontSize = 10,
-  padding = 4)
+  string = "{label}: {value}, {percentage}\%",
+  placeholderParser = NULL, fadeInSpeed = 250,
+  backgroundColor = "#000000", backgroundOpacity = 0.5,
+  color = "#efefef", borderRadius = 2, font = "arial",
+  fontSize = 10, padding = 4)
 }
 \arguments{
 \item{pier}{object}

--- a/man/pier.Rd
+++ b/man/pier.Rd
@@ -5,7 +5,8 @@
 \title{pier}
 \usage{
 pier(data, width = NULL, height = NULL, header = NULL,
-  sortOrder = "none", smallSegmentGrouping = FALSE, settings = NULL, ...)
+  sortOrder = "none", smallSegmentGrouping = FALSE, settings = NULL,
+  ...)
 }
 \arguments{
 \item{data}{data.frame must contain colnames value, label and color}


### PR DESCRIPTION
I added a quick check to see if a pie chart has been previously rendered inside the `renderValue` function. If a pie chart has been previously drawn, it is destroyed prior to drawing a new pie chart. This prevents multiple pie charts from appearing in a shiny application.  